### PR TITLE
test: add unit tests for CoqueGuide AI module

### DIFF
--- a/H3-CoqueGuide/H3-CoqueGuide.xcodeproj/project.pbxproj
+++ b/H3-CoqueGuide/H3-CoqueGuide.xcodeproj/project.pbxproj
@@ -6,8 +6,19 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXContainerItemProxy section */
+		94BCCD212F67B6230069322A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A58A5A42F6311E300A27D19 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A58A5AB2F6311E300A27D19;
+			remoteInfo = "H3-CoqueGuide";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		1A58A5AC2F6311E300A27D19 /* H3-CoqueGuide.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "H3-CoqueGuide.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		94BCCD1D2F67B6230069322A /* H3-CoqueGuideTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "H3-CoqueGuideTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -16,10 +27,22 @@
 			path = "H3-CoqueGuide";
 			sourceTree = "<group>";
 		};
+		94BCCD1E2F67B6230069322A /* H3-CoqueGuideTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "H3-CoqueGuideTests";
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		1A58A5A92F6311E300A27D19 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		94BCCD1A2F67B6230069322A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -33,6 +56,7 @@
 			isa = PBXGroup;
 			children = (
 				1A58A5AE2F6311E300A27D19 /* H3-CoqueGuide */,
+				94BCCD1E2F67B6230069322A /* H3-CoqueGuideTests */,
 				1A58A5AD2F6311E300A27D19 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -41,6 +65,7 @@
 			isa = PBXGroup;
 			children = (
 				1A58A5AC2F6311E300A27D19 /* H3-CoqueGuide.app */,
+				94BCCD1D2F67B6230069322A /* H3-CoqueGuideTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -70,6 +95,29 @@
 			productReference = 1A58A5AC2F6311E300A27D19 /* H3-CoqueGuide.app */;
 			productType = "com.apple.product-type.application";
 		};
+		94BCCD1C2F67B6230069322A /* H3-CoqueGuideTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 94BCCD232F67B6230069322A /* Build configuration list for PBXNativeTarget "H3-CoqueGuideTests" */;
+			buildPhases = (
+				94BCCD192F67B6230069322A /* Sources */,
+				94BCCD1A2F67B6230069322A /* Frameworks */,
+				94BCCD1B2F67B6230069322A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				94BCCD222F67B6230069322A /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				94BCCD1E2F67B6230069322A /* H3-CoqueGuideTests */,
+			);
+			name = "H3-CoqueGuideTests";
+			packageProductDependencies = (
+			);
+			productName = "H3-CoqueGuideTests";
+			productReference = 94BCCD1D2F67B6230069322A /* H3-CoqueGuideTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -77,11 +125,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2630;
+				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 2630;
 				TargetAttributes = {
 					1A58A5AB2F6311E300A27D19 = {
 						CreatedOnToolsVersion = 26.3;
+					};
+					94BCCD1C2F67B6230069322A = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = 1A58A5AB2F6311E300A27D19;
 					};
 				};
 			};
@@ -100,12 +152,20 @@
 			projectRoot = "";
 			targets = (
 				1A58A5AB2F6311E300A27D19 /* H3-CoqueGuide */,
+				94BCCD1C2F67B6230069322A /* H3-CoqueGuideTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		1A58A5AA2F6311E300A27D19 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		94BCCD1B2F67B6230069322A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -122,7 +182,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		94BCCD192F67B6230069322A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		94BCCD222F67B6230069322A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1A58A5AB2F6311E300A27D19 /* H3-CoqueGuide */;
+			targetProxy = 94BCCD212F67B6230069322A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		1A58A5B52F6311E600A27D19 /* Debug */ = {
@@ -310,6 +385,46 @@
 			};
 			name = Release;
 		};
+		94BCCD242F67B6230069322A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ernesto.H3-CoqueGuideTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/H3-CoqueGuide.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/H3-CoqueGuide";
+			};
+			name = Debug;
+		};
+		94BCCD252F67B6230069322A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ernesto.H3-CoqueGuideTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/H3-CoqueGuide.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/H3-CoqueGuide";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -327,6 +442,15 @@
 			buildConfigurations = (
 				1A58A5B82F6311E600A27D19 /* Debug */,
 				1A58A5B92F6311E600A27D19 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		94BCCD232F67B6230069322A /* Build configuration list for PBXNativeTarget "H3-CoqueGuideTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				94BCCD242F67B6230069322A /* Debug */,
+				94BCCD252F67B6230069322A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/H3-CoqueGuide/H3-CoqueGuideTests/CGAIServiceTests.swift
+++ b/H3-CoqueGuide/H3-CoqueGuideTests/CGAIServiceTests.swift
@@ -1,0 +1,126 @@
+//
+//  CGAIServiceTests.swift
+//  H3-CoqueGuideTests
+//
+//  Unit tests para el servicio de IA simulado.
+//
+
+import XCTest
+@testable import H3_CoqueGuide
+
+final class CGAIServiceTests: XCTestCase {
+
+    var service: CGSimulatedAIService!
+
+    override func setUp() {
+        super.setUp()
+        service = CGSimulatedAIService()
+    }
+
+    // MARK: - Respuestas por categoría
+
+    func testGreetingResponse() async {
+        let response = await service.processMessage("hola")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertFalse(response.text!.isEmpty)
+        XCTAssertTrue(response.cards.isEmpty)
+    }
+
+    func testMapResponse() async {
+        let response = await service.processMessage("mapa")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertFalse(response.cards.isEmpty, "Map response should include action cards")
+        XCTAssertEqual(response.cards.first?.cardType, .map)
+    }
+
+    func testEventsResponse() async {
+        let response = await service.processMessage("eventos")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertFalse(response.cards.isEmpty, "Events response should include event cards")
+        XCTAssertEqual(response.cards.first?.cardType, .event)
+    }
+
+    func testScanResponse() async {
+        let response = await service.processMessage("escanear")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertFalse(response.cards.isEmpty, "Scan response should include scan card")
+        XCTAssertEqual(response.cards.first?.cardType, .scan)
+    }
+
+    func testLanguageResponse() async {
+        let response = await service.processMessage("idioma")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertTrue(response.cards.isEmpty, "Language response should be text-only")
+    }
+
+    func testAccessibilityResponse() async {
+        let response = await service.processMessage("accesibilidad")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertTrue(response.cards.isEmpty)
+    }
+
+    func testAdmissionResponse() async {
+        let response = await service.processMessage("horario")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertTrue(response.cards.isEmpty)
+    }
+
+    func testMuseumInfoResponse() async {
+        let response = await service.processMessage("museo horno3")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertTrue(response.cards.isEmpty)
+    }
+
+    func testServicesResponse() async {
+        let response = await service.processMessage("restaurante")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertTrue(response.cards.isEmpty)
+    }
+
+    func testHelpResponse() async {
+        let response = await service.processMessage("ayuda")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertTrue(response.cards.isEmpty)
+    }
+
+    func testDefaultResponse() async {
+        let response = await service.processMessage("xyz123abc")
+
+        XCTAssertNotNil(response.text)
+        XCTAssertTrue(response.cards.isEmpty)
+    }
+
+    // MARK: - CGAIResponse factories
+
+    func testTextOnlyFactory() {
+        let response = CGAIResponse.textOnly("Test")
+
+        XCTAssertEqual(response.text, "Test")
+        XCTAssertTrue(response.cards.isEmpty)
+    }
+
+    func testWithCardsFactory() {
+        let card = CGActionCard(cardType: .info, title: "Info")
+        let response = CGAIResponse.withCards("Texto", cards: [card])
+
+        XCTAssertEqual(response.text, "Texto")
+        XCTAssertEqual(response.cards.count, 1)
+    }
+
+    // MARK: - Protocolo
+
+    func testConformsToProtocol() {
+        let _: CGAIServiceProtocol = CGSimulatedAIService()
+        // Si compila, conforma al protocolo
+    }
+}

--- a/H3-CoqueGuide/H3-CoqueGuideTests/CGActionCardTests.swift
+++ b/H3-CoqueGuide/H3-CoqueGuideTests/CGActionCardTests.swift
@@ -1,0 +1,98 @@
+//
+//  CGActionCardTests.swift
+//  H3-CoqueGuideTests
+//
+//  Unit tests para CGActionCard y tipos relacionados.
+//
+
+import XCTest
+@testable import H3_CoqueGuide
+
+final class CGActionCardTests: XCTestCase {
+
+    // MARK: - CGCardType
+
+    func testCardTypeActionLabels() {
+        XCTAssertEqual(CGCardType.event.actionLabel, "Ver evento")
+        XCTAssertEqual(CGCardType.map.actionLabel, "Ir al mapa")
+        XCTAssertEqual(CGCardType.scan.actionLabel, "Abrir escáner")
+        XCTAssertEqual(CGCardType.info.actionLabel, "Más información")
+    }
+
+    func testCardTypeDefaultIcons() {
+        XCTAssertEqual(CGCardType.event.defaultIcon, "calendar")
+        XCTAssertEqual(CGCardType.map.defaultIcon, "map")
+        XCTAssertEqual(CGCardType.scan.defaultIcon, "qrcode.viewfinder")
+        XCTAssertEqual(CGCardType.info.defaultIcon, "info.circle")
+    }
+
+    // MARK: - CGAppDestination
+
+    func testDestinationHashable() {
+        let destinations: Set<CGAppDestination> = [.map, .events, .scanning, .survey]
+        XCTAssertEqual(destinations.count, 4)
+    }
+
+    // MARK: - CGActionCard
+
+    func testCardCreationWithDefaults() {
+        let card = CGActionCard(cardType: .map, title: "Mapa del museo")
+
+        XCTAssertEqual(card.title, "Mapa del museo")
+        XCTAssertEqual(card.cardType, .map)
+        XCTAssertEqual(card.icon, "map") // uses defaultIcon
+        XCTAssertNil(card.subtitle)
+        XCTAssertNil(card.description)
+        XCTAssertNil(card.action)
+        XCTAssertNotNil(card.id)
+    }
+
+    func testCardCreationWithCustomIcon() {
+        let card = CGActionCard(cardType: .event, title: "Tour", icon: "star.fill")
+
+        XCTAssertEqual(card.icon, "star.fill")
+    }
+
+    func testCardCreationWithAllFields() {
+        let card = CGActionCard(
+            cardType: .scan,
+            title: "Escáner",
+            subtitle: "QR Code",
+            description: "Escanea objetos del museo",
+            icon: "camera",
+            action: .navigate(.scanning)
+        )
+
+        XCTAssertEqual(card.title, "Escáner")
+        XCTAssertEqual(card.subtitle, "QR Code")
+        XCTAssertEqual(card.description, "Escanea objetos del museo")
+        XCTAssertEqual(card.icon, "camera")
+    }
+
+    func testCardsHaveUniqueIds() {
+        let card1 = CGActionCard(cardType: .map, title: "A")
+        let card2 = CGActionCard(cardType: .map, title: "B")
+
+        XCTAssertNotEqual(card1.id, card2.id)
+    }
+
+    // MARK: - CGCardAction
+
+    func testNavigateAction() {
+        let action = CGCardAction.navigate(.map)
+        if case .navigate(let destination) = action {
+            XCTAssertEqual(destination, .map)
+        } else {
+            XCTFail("Expected navigate action")
+        }
+    }
+
+    func testSendMessageAction() {
+        let action = CGCardAction.sendMessage("Hola")
+        if case .sendMessage(let text) = action {
+            XCTAssertEqual(text, "Hola")
+        } else {
+            XCTFail("Expected sendMessage action")
+        }
+    }
+}

--- a/H3-CoqueGuide/H3-CoqueGuideTests/CGEventServiceTests.swift
+++ b/H3-CoqueGuide/H3-CoqueGuideTests/CGEventServiceTests.swift
@@ -1,0 +1,60 @@
+//
+//  CGEventServiceTests.swift
+//  H3-CoqueGuideTests
+//
+//  Unit tests para el servicio de eventos del museo.
+//
+
+import XCTest
+@testable import H3_CoqueGuide
+
+final class CGEventServiceTests: XCTestCase {
+
+    // MARK: - Singleton
+
+    func testSharedInstance() {
+        let instance1 = CGEventService.shared
+        let instance2 = CGEventService.shared
+
+        XCTAssertTrue(instance1 === instance2, "Should return same singleton instance")
+    }
+
+    // MARK: - Today's Events
+
+    func testTodaysEventsCount() {
+        let events = CGEventService.shared.todaysEvents()
+
+        XCTAssertEqual(events.count, 4)
+    }
+
+    func testTodaysEventsHaveRequiredFields() {
+        let events = CGEventService.shared.todaysEvents()
+
+        for event in events {
+            XCTAssertFalse(event.id.isEmpty, "Event ID should not be empty")
+            XCTAssertFalse(event.name.isEmpty, "Event name should not be empty")
+            XCTAssertFalse(event.time.isEmpty, "Event time should not be empty")
+            XCTAssertFalse(event.location.isEmpty, "Event location should not be empty")
+            XCTAssertFalse(event.description.isEmpty, "Event description should not be empty")
+            XCTAssertFalse(event.icon.isEmpty, "Event icon should not be empty")
+        }
+    }
+
+    func testTodaysEventsHaveUniqueIds() {
+        let events = CGEventService.shared.todaysEvents()
+        let ids = events.map { $0.id }
+        let uniqueIds = Set(ids)
+
+        XCTAssertEqual(ids.count, uniqueIds.count, "All event IDs should be unique")
+    }
+
+    // MARK: - Next Event
+
+    func testNextEventReturnsFirst() {
+        let nextEvent = CGEventService.shared.nextEvent()
+        let firstEvent = CGEventService.shared.todaysEvents().first
+
+        XCTAssertNotNil(nextEvent)
+        XCTAssertEqual(nextEvent?.id, firstEvent?.id)
+    }
+}

--- a/H3-CoqueGuide/H3-CoqueGuideTests/CGMessageTests.swift
+++ b/H3-CoqueGuide/H3-CoqueGuideTests/CGMessageTests.swift
@@ -1,0 +1,104 @@
+//
+//  CGMessageTests.swift
+//  H3-CoqueGuideTests
+//
+//  Unit tests para los modelos de datos de CoqueGuide.
+//
+
+import XCTest
+@testable import H3_CoqueGuide
+
+final class CGMessageTests: XCTestCase {
+
+    // MARK: - CGMessage
+
+    func testUserMessageFactory() {
+        let message = CGMessage.userMessage("Hola")
+
+        XCTAssertEqual(message.text, "Hola")
+        XCTAssertEqual(message.sender, .user)
+        XCTAssertTrue(message.cards.isEmpty)
+        XCTAssertNotNil(message.id)
+    }
+
+    func testGuideMessageFactory() {
+        let message = CGMessage.guideMessage("Bienvenido")
+
+        XCTAssertEqual(message.text, "Bienvenido")
+        XCTAssertEqual(message.sender, .coqueGuide)
+        XCTAssertTrue(message.cards.isEmpty)
+    }
+
+    func testGuideMessageWithCardsFactory() {
+        let card = CGActionCard(cardType: .map, title: "Mapa")
+        let message = CGMessage.guideMessage("Texto", cards: [card])
+
+        XCTAssertEqual(message.text, "Texto")
+        XCTAssertEqual(message.sender, .coqueGuide)
+        XCTAssertEqual(message.cards.count, 1)
+        XCTAssertEqual(message.cards.first?.title, "Mapa")
+    }
+
+    func testGuideMessageWithNilText() {
+        let message = CGMessage.guideMessage(nil, cards: [])
+
+        XCTAssertNil(message.text)
+        XCTAssertEqual(message.sender, .coqueGuide)
+    }
+
+    func testMessageHasUniqueIds() {
+        let msg1 = CGMessage.userMessage("A")
+        let msg2 = CGMessage.userMessage("B")
+
+        XCTAssertNotEqual(msg1.id, msg2.id)
+    }
+
+    func testMessageTimestamp() {
+        let before = Date()
+        let message = CGMessage.userMessage("Test")
+        let after = Date()
+
+        XCTAssertGreaterThanOrEqual(message.timestamp, before)
+        XCTAssertLessThanOrEqual(message.timestamp, after)
+    }
+
+    // MARK: - CGSuggestion
+
+    func testSuggestionCreation() {
+        let suggestion = CGSuggestion(text: "¿Quieres ver el mapa?", icon: "map")
+
+        XCTAssertEqual(suggestion.text, "¿Quieres ver el mapa?")
+        XCTAssertEqual(suggestion.icon, "map")
+        XCTAssertNotNil(suggestion.id)
+    }
+
+    func testSuggestionsHaveUniqueIds() {
+        let s1 = CGSuggestion(text: "A", icon: "map")
+        let s2 = CGSuggestion(text: "B", icon: "star")
+
+        XCTAssertNotEqual(s1.id, s2.id)
+    }
+
+    // MARK: - CGQuickAction
+
+    func testQuickActionCreation() {
+        let action = CGQuickAction(title: "Ver mapa", icon: "map", message: "Muestra el mapa")
+
+        XCTAssertEqual(action.title, "Ver mapa")
+        XCTAssertEqual(action.icon, "map")
+        XCTAssertEqual(action.message, "Muestra el mapa")
+        XCTAssertNotNil(action.id)
+    }
+
+    func testDefaultQuickActionsCount() {
+        XCTAssertEqual(CGQuickAction.defaults.count, 5)
+    }
+
+    func testDefaultQuickActionsHaveContent() {
+        for action in CGQuickAction.defaults {
+            XCTAssertFalse(action.title.isEmpty, "Quick action title should not be empty")
+            XCTAssertFalse(action.icon.isEmpty, "Quick action icon should not be empty")
+            XCTAssertFalse(action.message.isEmpty, "Quick action message should not be empty")
+        }
+    }
+}

--- a/H3-CoqueGuide/H3-CoqueGuideTests/CGNavigationCoordinatorTests.swift
+++ b/H3-CoqueGuide/H3-CoqueGuideTests/CGNavigationCoordinatorTests.swift
@@ -1,0 +1,62 @@
+//
+//  CGNavigationCoordinatorTests.swift
+//  H3-CoqueGuideTests
+//
+//  Unit tests para el coordinador de navegación.
+//
+
+import XCTest
+@testable import H3_CoqueGuide
+
+final class CGNavigationCoordinatorTests: XCTestCase {
+
+    var coordinator: CGNavigationCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        coordinator = CGNavigationCoordinator()
+    }
+
+    func testInitialStateIsNil() {
+        XCTAssertNil(coordinator.pendingDestination)
+    }
+
+    func testNavigateSetsDestination() {
+        coordinator.navigate(to: .map)
+
+        XCTAssertEqual(coordinator.pendingDestination, .map)
+    }
+
+    func testConsumeDestinationReturnsAndClears() {
+        coordinator.navigate(to: .events)
+
+        let consumed = coordinator.consumeDestination()
+
+        XCTAssertEqual(consumed, .events)
+        XCTAssertNil(coordinator.pendingDestination, "Destination should be cleared after consuming")
+    }
+
+    func testConsumeDestinationReturnsNilWhenEmpty() {
+        let consumed = coordinator.consumeDestination()
+
+        XCTAssertNil(consumed)
+    }
+
+    func testNavigateOverwritesPreviousDestination() {
+        coordinator.navigate(to: .map)
+        coordinator.navigate(to: .scanning)
+
+        XCTAssertEqual(coordinator.pendingDestination, .scanning)
+    }
+
+    func testAllDestinations() {
+        let destinations: [CGAppDestination] = [.map, .events, .scanning, .survey]
+
+        for dest in destinations {
+            coordinator.navigate(to: dest)
+            XCTAssertEqual(coordinator.pendingDestination, dest)
+            let consumed = coordinator.consumeDestination()
+            XCTAssertEqual(consumed, dest)
+        }
+    }
+}

--- a/H3-CoqueGuide/H3-CoqueGuideTests/CGViewModelTests.swift
+++ b/H3-CoqueGuide/H3-CoqueGuideTests/CGViewModelTests.swift
@@ -1,0 +1,130 @@
+//
+//  CGViewModelTests.swift
+//  H3-CoqueGuideTests
+//
+//  Unit tests para el ViewModel principal de CoqueGuide.
+//
+
+import XCTest
+@testable import H3_CoqueGuide
+
+// MARK: - Mock AI Service para tests
+
+final class MockAIService: CGAIServiceProtocol {
+    var lastReceivedMessage: String?
+    var responseToReturn: CGAIResponse = .textOnly("Mock response")
+    var processMessageCallCount = 0
+
+    func processMessage(_ text: String) async -> CGAIResponse {
+        lastReceivedMessage = text
+        processMessageCallCount += 1
+        return responseToReturn
+    }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class CGViewModelTests: XCTestCase {
+
+    var viewModel: CGViewModel!
+    var mockService: MockAIService!
+
+    override func setUp() {
+        super.setUp()
+        mockService = MockAIService()
+        viewModel = CGViewModel(aiService: mockService)
+    }
+
+    // MARK: - Estado inicial
+
+    func testInitialState() {
+        XCTAssertTrue(viewModel.messages.isEmpty)
+        XCTAssertFalse(viewModel.isThinking)
+        XCTAssertFalse(viewModel.isPanelOpen)
+        XCTAssertNil(viewModel.activeSuggestion)
+        XCTAssertEqual(viewModel.pendingSuggestionsCount, 0)
+    }
+
+    // MARK: - Open Panel
+
+    func testOpenPanelSetsPanelOpen() {
+        viewModel.openPanel()
+
+        XCTAssertTrue(viewModel.isPanelOpen)
+    }
+
+    func testOpenPanelClearsSuggestion() {
+        viewModel.openPanel()
+
+        XCTAssertNil(viewModel.activeSuggestion)
+        XCTAssertEqual(viewModel.pendingSuggestionsCount, 0)
+    }
+
+    // MARK: - Send Message
+
+    func testSendMessageAddsUserMessage() {
+        viewModel.sendMessage("Hola")
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages.first?.text, "Hola")
+        XCTAssertEqual(viewModel.messages.first?.sender, .user)
+    }
+
+    func testSendEmptyMessageDoesNothing() {
+        viewModel.sendMessage("")
+
+        XCTAssertTrue(viewModel.messages.isEmpty)
+    }
+
+    func testSendWhitespaceMessageDoesNothing() {
+        viewModel.sendMessage("   ")
+
+        XCTAssertTrue(viewModel.messages.isEmpty)
+    }
+
+    func testSendMessageTrimsWhitespace() {
+        viewModel.sendMessage("  Hola  ")
+
+        XCTAssertEqual(viewModel.messages.first?.text, "Hola")
+    }
+
+    func testSendMessageCallsAIService() async throws {
+        viewModel.sendMessage("Test")
+
+        // Wait for async response
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertEqual(mockService.lastReceivedMessage, "Test")
+        XCTAssertEqual(mockService.processMessageCallCount, 1)
+    }
+
+    func testSendMessageAddsAIResponse() async throws {
+        mockService.responseToReturn = .textOnly("Respuesta de prueba")
+        viewModel.sendMessage("Test")
+
+        // Wait for async response
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages.last?.text, "Respuesta de prueba")
+        XCTAssertEqual(viewModel.messages.last?.sender, .coqueGuide)
+    }
+
+    // MARK: - Quick Actions
+
+    func testHandleQuickAction() {
+        let action = CGQuickAction(title: "Test", icon: "star", message: "Mensaje de prueba")
+        viewModel.handleQuickAction(action)
+
+        XCTAssertEqual(viewModel.messages.first?.text, "Mensaje de prueba")
+    }
+
+    // MARK: - Suggestions
+
+    func testDismissSuggestion() {
+        viewModel.dismissSuggestion()
+
+        XCTAssertNil(viewModel.activeSuggestion)
+    }
+}


### PR DESCRIPTION
- CGMessageTests: message factories, suggestions, quick actions
- CGActionCardTests: card types, destinations, actions
- CGAIServiceTests: simulated AI service responses by category
- CGEventServiceTests: event service singleton and data
- CGNavigationCoordinatorTests: navigation coordinator state
- CGViewModelTests: ViewModel state, messaging, mock service